### PR TITLE
build: Changing makefile to exclude msp430.h from cppcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ MSP430_FLASHER = LD_LIBRARY_PATH=$(MSP430_FLASHER_DIR) $(MSP430_FLASHER_DIR)/MSP
 CREATE_HEX_OUTFILE = $(MSPGCC_BIN_DIR)/msp430-elf-objcopy
 CPPCHECK = cppcheck
 FORMAT = clang-format-14
+
 # Files
 ## Output Files
 TARGET = $(BIN_DIR)/run_sumobot
@@ -87,17 +88,22 @@ $(OBJ_DIR)/%.o: $(FW_DIR)/%.c
 all: $(TARGET)
 
 clean:
-	$(RM) -r $(BUILD_DIR)
+	$(RM) -rf $(BUILD_DIR)
 
 flash: $(HEX_FILE)
 	/bin/bash -c "$(MSP430_FLASHER) $(FLASH_FLAGS)"
 
+CPPCHECK_INCLUDES = $(FW_DIR)
+CPPCHECK_IGNORE = externals/printf
 cppcheck: 
 	@$(CPPCHECK) --quiet --enable=all --error-exitcode=1 --inline-suppr \
-		-I $(INCLUDE_DIRS) \
-		-i externals/printf \
+		$(addprefix -I, $(CPPCHECK_INCLUDES)) \
+		$(addprefix -i, $(CPPCHECK_IGNORE)) \
 		-v \
+		--suppress=missingIncludeSystem \
+		--suppress=unmatchedSuppression \
+		--suppress=unusedFunction \
 		$(SRC_FILES)
 
 format:
-	@$(FORMAT) -i $(SRC_FILES) $(HEADER_FILES)
+	$(FORMAT) --verbose -i $(SRC_FILES) $(HEADER_FILES)

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -1,2 +1,3 @@
+#include <msp430.h>
 
 int main(void) { return 0; }


### PR DESCRIPTION
Cppcheck is slow checking all of the ifdef's, which msp430.h contains many of. This slows down cppcheck because it checks all the ifdef combinations. Because this file is provided by TI, there is no need to check this file, so we are excluding it from the cppcheck. Suppress the error about missing system includes (ignores standard includes <>) and supress errors about unmatched supressions and unused functions.

Also adding -f flag to make "clean" to return ok even when there is no "build" directory.