### PR TITLE
Added *.o to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore build directory
 build/
+*.o
+


### PR DESCRIPTION
 Adding *.o to .gitignore to not commit generated object files outside of build/ like in externals/printf/. 
printf.o is generated when compiling because of compiling printf.c file from submodule, but we don't want to include object files.