### PR TITLE
feat(LED assert): Adding assert for test LED and HW detection.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,22 +61,25 @@ HEX_FILE = $(TARGET).hex
 
 ## Input Files
 SRC_FILES_APP = drive.c enemy.c
-SRC_FILES_DRIVERS = io.c
+SRC_FILES_DRIVERS = io.c led.c
 SRC_FILES_TEST = test.c
 SRC_FILES_MOTOR = motors.c
+SRC_FILES_COMMON = assert_handler.c
 SRC_FILES = $(FW_DIR)/main.c \
 			externals/printf/printf.c \
 			$(addprefix $(APP_DIR)/, $(SRC_FILES_APP)) \
 			$(addprefix $(DRIVERS_DIR)/, $(SRC_FILES_DRIVERS)) \
 			$(addprefix $(TEST_DIR)/, $(SRC_FILES_TEST)) \
-			$(addprefix $(MOTORS_DIR)/, $(SRC_FILES_MOTOR))
+			$(addprefix $(MOTORS_DIR)/, $(SRC_FILES_MOTOR)) \
+			$(addprefix $(COMMON_DIR)/, $(SRC_FILES_COMMON))
 
 HEADER_FILES = $(COMMON_DIR)/defines.h \
 	externals/printf/printf.h \
 	$(addprefix $(APP_DIR)/, $(SRC_FILES_APP:.c=.h)) \
 	$(addprefix $(DRIVERS_DIR)/, $(SRC_FILES_DRIVERS:.c=.h))  \
 	$(addprefix $(TEST_DIR)/, $(SRC_FILES_TEST:.c=.h)) \
-	$(addprefix $(MOTORS_DIR)/, $(SRC_FILES_MOTOR:.c=.h))
+	$(addprefix $(MOTORS_DIR)/, $(SRC_FILES_MOTOR:.c=.h)) \
+	$(addprefix $(COMMON_DIR)/, $(SRC_FILES_COMMON:.c=.h))
 
 OBJ_NAMES = $(SRC_FILES:.c=.o)
 OBJ_FILES = $(patsubst $(FW_DIR)/%, $(OBJ_DIR)/%, $(OBJ_NAMES))

--- a/src/fw/common/assert_handler.c
+++ b/src/fw/common/assert_handler.c
@@ -1,0 +1,16 @@
+#include "assert_handler.h"
+
+/* The TI compiler provides intrinsic support for calling a specific opcode, 
+ * which means you can write __op_code(0x4343) to trigger a software breakpoint 
+ * (When LAUNCHPAD FET debugger is attached). MSP430-GCC does not have this 
+ * intrinsic function, but 0x4343 corresponds to assumly instruction "CLR.B R3".
+ */
+#define BREAKPOINT __asm volatile("CLR.B R3");
+
+void assert_handler(void) {
+    // TODO: Turn off motors ("safe state")
+    // TODO: Trace to console
+    BREAKPOINT
+    // TODO: Blink LED indefinitely
+    while(1) {};
+}

--- a/src/fw/common/assert_handler.h
+++ b/src/fw/common/assert_handler.h
@@ -1,0 +1,13 @@
+#ifndef ASSERT_HANDLER_H
+
+#define ASSERT(expression) \
+        do { \
+                if (!(expression)) { \
+                        assert_handler(); \
+                } \
+        } while(0);
+
+void assert_handler(void);
+
+#endif // ASSERT_HANDLER_H
+

--- a/src/fw/drivers/io.h
+++ b/src/fw/drivers/io.h
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 
 /* IO pin handling, including pinmapping, initialization, and configurations
  * This wraps the register defines provided in the headers from Texas
@@ -194,6 +195,7 @@ typedef enum {
     
     // IO Test LED  
     IO_TEST_LED = IO_10, // P1.0
+    
     // Motor pins (IN1 -> AIN1 and BIN1, IN2 -> AIN2 and BIN2) (Motors on same
     // sides will share same PWM input signal)
     MOTOR_RIGHT_IN1 = IO_25, // P2.5
@@ -352,3 +354,5 @@ void io_set_ren(io_signal_enum pin, io_ren_enum enable);
 void io_set_out(io_signal_enum pin, io_out_enum out);
 void config_io(io_signal_enum pin, const struct io_config *config);
 void io_init(void);
+void io_get_current_config(io_signal_enum pin, struct io_config *config);
+bool io_config_compare(const struct io_config *cfg1, const struct io_config *cfg2);

--- a/src/fw/drivers/led.c
+++ b/src/fw/drivers/led.c
@@ -1,0 +1,32 @@
+#include "led.h"
+#include "common/assert_handler.h"
+#include "drivers/io.h"
+#include "common/defines.h"
+#include <stdbool.h>
+
+static bool initialized = false;
+
+static const struct io_config led_config = {
+    .io_sel = IO_SEL_GPIO,
+    .io_dir = IO_DIR_OUTPUT,
+    .io_ren = IO_REN_DISABLE,
+    .io_out = IO_OUT_LOW 
+};
+
+void led_init(void) {
+    ASSERT(!initialized);
+    struct io_config current_config;
+    io_get_current_config(IO_TEST_LED, &current_config);
+    ASSERT(io_config_compare(&current_config, &led_config));
+    initialized = true;
+}
+
+void set_led(led_enum led, led_state_enum state) {
+    ASSERT(initialized);
+    const io_out_enum out = (state == LED_STATE_OFF) ? IO_OUT_LOW : IO_OUT_HIGH;
+    switch(led) {
+        case TEST_LED:
+           io_set_out(IO_TEST_LED, out);
+           break;
+    }
+}

--- a/src/fw/drivers/led.h
+++ b/src/fw/drivers/led.h
@@ -1,0 +1,13 @@
+#ifndef LED_H
+    typedef enum {
+        TEST_LED
+    } led_enum;
+
+    typedef enum {
+            LED_STATE_ON,
+            LED_STATE_OFF
+    } led_state_enum;
+
+    void led_init(void);
+    void set_led(led_enum led, led_state_enum state);
+#endif // LED_H

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -1,5 +1,6 @@
 #include "printf.h"
-#include <drivers/io.h>
+#include "drivers/io.h"
+#include "drivers/led.h"
 #include <msp430.h>
 #include <stdint.h>
 
@@ -10,16 +11,20 @@ int main(void) {
                  // running because it keeps restarting from watchdog timeout
     io_init();
     const struct io_config led_config = {
-        .io_dir = IO_DIR_OUTPUT,
         .io_sel = IO_SEL_GPIO,
+        .io_dir = IO_DIR_OUTPUT,
         .io_ren = IO_REN_DISABLE,
-        .io_out = IO_OUT_HIGH,
+        .io_out = IO_OUT_LOW
     };
     config_io(IO_TEST_LED, &led_config);
-    io_out_enum io_out = IO_OUT_LOW;
+    //io_out_enum io_out = IO_OUT_LOW;
+    led_init(); // Check that IO_TEST_LED config is correct
+    led_state_enum led_state = LED_STATE_ON; 
     while (1) {
         __delay_cycles(1000000);
-        io_out = (io_out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
-        io_set_out(IO_TEST_LED, io_out);
+        led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+        set_led(TEST_LED, led_state);
+        //io_out = (io_out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
+        //io_set_out(IO_TEST_LED, io_out);
     }
 }


### PR DESCRIPTION
HW detection specified in make cmd with HW=SUMOBOT or HW=LAUNCHPAD. If specifying wrong HW, then an assert is triggered, hanging the device in an endless while loop. Tested with blinking IO_TEST_LED, which will be used later when an assert happens, endlessly blink the LED until device is restarted. Currently, Launchpad has pulldown resistor on IO_TEST_LED. This should be removed later by disabling the pulldown resistor and connecting a jumper from IO_TEST_LED to GND, because when left floating, for some reason it pulls high naturally, meaning the assert is triggered.