### PR TITLE
feat(test_functions): Handle test functions better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,6 @@ jobs:
         run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=LAUNCHPAD
       - name: Build (compile and link) code for SumoBot (PCB)
         run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=SUMOBOT
+      - name: Run test script that builds all of the test functions
+        run: TOOLS_PATH=/home/ubuntu/dev/tools tools/build_tests.sh 
 

--- a/src/fw/common/defines.h
+++ b/src/fw/common/defines.h
@@ -1,3 +1,5 @@
+#define SUPPRESS_UNUSED __attribute__((unused))
+
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
 #define CYCLES_1MHZ (1000000U)

--- a/src/fw/drivers/mcu_init.c
+++ b/src/fw/drivers/mcu_init.c
@@ -1,0 +1,9 @@
+#include <msp430.h>
+
+void mcu_init(void) {
+    WDTCTL =
+        WDTPW |
+        WDTHOLD; // stop watchdog timer, otherwise it prevents program from
+                 // running because it keeps restarting from watchdog timeout
+}
+

--- a/src/fw/drivers/mcu_init.h
+++ b/src/fw/drivers/mcu_init.h
@@ -1,0 +1,2 @@
+
+void mcu_init(void);

--- a/src/fw/test/test.c
+++ b/src/fw/test/test.c
@@ -1,0 +1,40 @@
+#include <msp430.h>
+#include <stdint.h>
+#include "drivers/mcu_init.h"
+#include "drivers/led.h"
+#include "drivers/io.h"
+#include "common/defines.h"
+#include "common/assert_handler.h"
+
+SUPPRESS_UNUSED
+static void test_setup(void) {
+    mcu_init();
+}
+
+SUPPRESS_UNUSED
+static void test_assert(void) {
+    test_setup();
+    ASSERT(0);
+}
+
+SUPPRESS_UNUSED
+static void test_blink_led(void) {
+    test_setup();
+    const struct io_config led_config = {.io_sel = IO_SEL_GPIO,
+                                         .io_dir = IO_DIR_OUTPUT,
+                                         .io_ren = IO_REN_DISABLE,
+                                         .io_out = IO_OUT_LOW};
+    config_io(IO_TEST_LED, &led_config);
+    led_init(); // Check that IO_TEST_LED config is correct
+    led_state_enum led_state = LED_STATE_ON;
+    while (1) {
+        BUSY_WAIT_ms(1000)
+        led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+        set_led(TEST_LED, led_state);
+    }
+}
+
+int main() {
+    TEST(); // Define passed to Makefile to run a specific test function
+    ASSERT(0);
+}

--- a/src/fw/test/test.h
+++ b/src/fw/test/test.h
@@ -1,0 +1,5 @@
+
+
+static void test_setup(void);
+static void test_assert(void);
+static void test_blink_led(void);

--- a/tools/build_tests.sh
+++ b/tools/build_tests.sh
@@ -1,0 +1,12 @@
+#!bin/bash
+
+# This script is used by CI to build all test functions
+
+SCRIPT_DIR=$(dirname "$0")
+TEST_FUNCTIONS=$(cat src/fw/test/test.c | grep -P '(?<=void )test_.+(?=\()' -o)
+
+for test_function in $TEST_FUNCTIONS
+do
+        make HW=LAUNCHPAD TEST=$test_function
+        make HW=SUMOBOT TEST=$test_function
+done

--- a/tools/build_tests.sh
+++ b/tools/build_tests.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/usr/bin/bash
 
 # This script is used by CI to build all test functions
 


### PR DESCRIPTION
Moving test functions to test.c instead of keeping in main.c. Also building separate object files for each test function in Makefile and adding as part of CI. This will allow compiling and building individual test functions as executable binaries that can be run standalone on the launchpad or PCB.