### PR TITLE
feat(pwm): Add pwm driver control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ else
 MAIN_SRC_FILE = $(TEST_DIR)/$(TEST).c
 endif
 SRC_FILES_APP = drive.c enemy.c
-SRC_FILES_DRIVERS = io.c led.c mcu_init.c uart.c ring_buffer.c
+SRC_FILES_DRIVERS = io.c led.c mcu_init.c uart.c ring_buffer.c pwm.c
 SRC_FILES_MOTOR = motors.c
 SRC_FILES_COMMON = assert_handler.c trace.c
 SRC_FILES_PRINTF = printf.c

--- a/src/fw/common/assert_handler.c
+++ b/src/fw/common/assert_handler.c
@@ -1,6 +1,6 @@
 #include "assert_handler.h"
-#include "drivers/uart.h"
 #include "common/defines.h"
+#include "drivers/uart.h"
 #include "externals/printf/printf.h"
 #include <msp430.h>
 
@@ -14,20 +14,21 @@
 // Text + Program Counter + Null termination
 #define ASSERT_STRING_MAX_SIZE (15u + 6u + 1u)
 
-/** 
+/**
  * Print trace of where ASSERT was triggered
  */
 void assert_trace(uint16_t program_counter) {
-//    #ifdef LAUNCHPAD
-//        P4SEL |= (BIT4 | BIT5);
-//        P4DIR |= BIT4;
-//        P4DIR &= ~BIT5;
-//    #elif SUMOBOT
-//        P3SEL |= (BIT3 | BIT4);
-//        P3DIR |= BIT3;
-//        P3DIR &= ~BIT4;
-//    #endif
-    uart_init_assert(); // Selecting UART function on pins already handled in mcu_init() via io_init()
+    //    #ifdef LAUNCHPAD
+    //        P4SEL |= (BIT4 | BIT5);
+    //        P4DIR |= BIT4;
+    //        P4DIR &= ~BIT5;
+    //    #elif SUMOBOT
+    //        P3SEL |= (BIT3 | BIT4);
+    //        P3DIR |= BIT3;
+    //        P3DIR &= ~BIT4;
+    //    #endif
+    uart_init_assert(); // Selecting UART function on pins already handled in
+                        // mcu_init() via io_init()
     char assert_str[ASSERT_STRING_MAX_SIZE];
     snprintf(assert_str, sizeof(assert_str), "ASSERT 0x%x\n", program_counter);
     uart_trace_assert(assert_str);
@@ -52,7 +53,7 @@ void assert_blink_led(void) {
 
 void assert_handler(uint16_t program_counter) {
     // TODO: Turn off motors ("safe state")
-    
+
     BREAKPOINT
     assert_trace(program_counter);
     assert_blink_led();

--- a/src/fw/common/assert_handler.h
+++ b/src/fw/common/assert_handler.h
@@ -3,18 +3,19 @@
 
 #define ASSERT(expression)                                                     \
     do {                                                                       \
-        if (!expression) {                                                   \
-            uint16_t pc; \
-            pc = (uint16_t)__builtin_return_address(0); \
-            assert_handler(pc);                                                  \
+        if (!expression) {                                                     \
+            uint16_t pc;                                                       \
+            pc = (uint16_t)__builtin_return_address(0);                        \
+            assert_handler(pc);                                                \
         }                                                                      \
     } while (0);
 
-#define ASSERT_INTERRUPT(expression)                                                     \
+#define ASSERT_INTERRUPT(expression)                                           \
     do {                                                                       \
         if (!(expression)) {                                                   \
-            while(1) {}  \
-        }                                                                     \
+            while (1) {                                                        \
+            }                                                                  \
+        }                                                                      \
     } while (0);
 
 void assert_trace(uint16_t);

--- a/src/fw/common/defines.h
+++ b/src/fw/common/defines.h
@@ -9,3 +9,6 @@
 #define CYCLES_PER_MS (CYCLES_16MHZ / 1000U)
 #define ms_TO_CYCLES(ms) (CYCLES_PER_MS * ms)
 #define BUSY_WAIT_ms(ms) __delay_cycles(ms_TO_CYCLES(ms));
+
+#define SMCLK (CYCLES_16MHZ)
+#define TIMER_INPUT_DIVIER_3 (8U)

--- a/src/fw/drivers/mcu_init.c
+++ b/src/fw/drivers/mcu_init.c
@@ -40,7 +40,10 @@ static void init_clocks() {
     // Step 4: Wait for the DCO to settle
     // (n × 32 × 32) fFLLREFCLK cycles for the DCO to settle worse case (1 * 32
     // * 32 = 1024)
-    __delay_cycles(50000); // Delay for DCO stabilization (Waiting much longer than 5000 cycles, because need more time for everything to settle in order for UART prints to display correctly)
+    __delay_cycles(
+        100000); // Delay for DCO stabilization (Waiting much longer than 5000
+                 // cycles, because need more time for everything to settle in
+                 // order for UART prints to display correctly)
 
     // Step 5: Select DCO as clock source for MCLK and SCLK, and REFO as clock
     // source for ACLK MUST select REFOCLK for ACLK (SELA) BEFORE clearing

--- a/src/fw/drivers/pwm.c
+++ b/src/fw/drivers/pwm.c
@@ -1,0 +1,141 @@
+#include "drivers/pwm.h"
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include "common/trace.h"
+#include "drivers/io.h"
+#include <assert.h>
+#include <msp430.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define PWM_TIMER_FREQ_HZ (SMCLK / TIMER_INPUT_DIVIER_3)
+#define PWM_PERIOD_FREQ_HZ (20000U)
+#define PWM_PERIOD_TICKS (PWM_TIMER_FREQ_HZ / PWM_PERIOD_FREQ_HZ)
+static_assert(PWM_PERIOD_TICKS == 100, "Expect 100 ticks per period");
+
+#define PWM_TAxCCR0                                                            \
+    (PWM_PERIOD_TICKS - 1) // Subtract 1 because timer counts from 0
+static bool initialized = false;
+static const struct io_config pwm_io_config = {.io_sel = IO_SEL_ALT2,
+                                               .io_dir = IO_DIR_OUTPUT,
+                                               .io_ren = IO_REN_DISABLE,
+                                               .io_out = IO_OUT_LOW};
+
+struct pwm_channel_cfg {
+    bool enable;
+    volatile unsigned int *const cctl;
+    volatile unsigned int *const ccr;
+};
+
+static struct pwm_channel_cfg pwm_cfgs[] = {
+    [MOTOR_RIGHT_IN1] = {.enable = false, .cctl = &TA2CCTL2, .ccr = &TA2CCR2},
+    [MOTOR_RIGHT_IN2] = {.enable = false, .cctl = &TA2CCTL1, .ccr = &TA2CCR1},
+    [MOTOR_LEFT_IN1] = {.enable = false, .cctl = &TA0CCTL4, .ccr = &TA0CCR4},
+    [MOTOR_LEFT_IN2] = {.enable = false, .cctl = &TA0CCTL3, .ccr = &TA0CCR3}};
+
+/**
+ * Initialize PWM timer registers
+ */
+void pwm_init(void) {
+    ASSERT(!initialized);
+
+    // Check that motor driver input pins are configured correctly
+    struct io_config mdrv_r1_io_config, mdrv_r2_io_config, mdrv_l1_io_config,
+        mdrv_l2_io_config;
+    io_get_current_config(MOTOR_RIGHT_IN1, &mdrv_r1_io_config);
+    io_get_current_config(MOTOR_RIGHT_IN2, &mdrv_r2_io_config);
+    io_get_current_config(MOTOR_LEFT_IN1, &mdrv_l1_io_config);
+    io_get_current_config(MOTOR_LEFT_IN2, &mdrv_l2_io_config);
+    // TRACE("PWM io config io_sel = %d", pwm_io_config.io_sel);
+    // TRACE("MDRV_L1 io_sel = %d", mdrv_l1_io_config.io_sel);
+    // TRACE("PWM io config io_dir = %d", pwm_io_config.io_dir);
+    // TRACE("MDRV_L1 io_dir = %d", mdrv_l1_io_config.io_dir);
+    // TRACE("PWM io config io_ren = %d", pwm_io_config.io_ren);
+    // TRACE("MDRV_L1 io_ren = %d", mdrv_l1_io_config.io_ren);
+    // TRACE("PWM io config io_out = %d", pwm_io_config.io_out);
+    // TRACE("MDRV_L1 io_out = %d", mdrv_l1_io_config.io_out);
+    ASSERT(io_config_compare(&pwm_io_config, &mdrv_r1_io_config));
+    ASSERT(io_config_compare(&pwm_io_config, &mdrv_r2_io_config));
+    ASSERT(io_config_compare(&pwm_io_config, &mdrv_l1_io_config));
+    ASSERT(io_config_compare(&pwm_io_config, &mdrv_l2_io_config));
+    /**
+     * TAxCTL0: [Reserved (15-10), TASSEL (9-8), ID (7-6), MC (5-4), Reserved
+     * (3), TACLR (2), TAIE (1), TAIFG (0)] TASSEL = 2 (Clock source SMCLK) ID =
+     * 3 (Divide clock source by 8) MC = 0 (Timer Mode: Halted)
+     */
+    TA0CTL |= (TASSEL_2 | ID_3 | MC_0);
+    TA2CTL |= (TASSEL_2 | ID_3 | MC_0);
+    TA0CCR0 = PWM_TAxCCR0;
+    TA2CCR0 = PWM_TAxCCR0;
+    initialized = true;
+}
+
+/**
+ * Checks if all pwm channels (motor drive inputs) are disabled
+ */
+static bool pwm_ch_all_disabled() {
+    for (uint8_t ch = 0; ch < ARRAY_SIZE(pwm_cfgs); ch++) {
+        if (pwm_cfgs[ch].enable)
+            return false;
+    }
+    return true;
+}
+
+/**
+ * Resets timer and sets timer to count up mode
+ */
+static void pwm_enable(bool enable) {
+    /**
+     * MC_0: Timer is halted
+     * MC_1: Up mode (Count up to TAxCCR0)
+     */
+    TA0CTL = (enable ? MC_1 : MC_0) + TACLR;
+    TA2CTL = (enable ? MC_1 : MC_0) + TACLR;
+}
+
+/**
+ * Enables PWM channel that connects to motor driver
+ * or disables all PWM channels if they are all off
+ */
+static void pwm_channel_enable(mdrv_enum mdrv, bool enable) {
+    if (pwm_cfgs[mdrv].enable != enable) {
+        *pwm_cfgs[mdrv].cctl = enable ? OUTMOD_7 : OUTMOD_0;
+        pwm_cfgs[mdrv].enable = enable;
+        if (enable) {
+            pwm_enable(true);
+        } else if (pwm_ch_all_disabled()) {
+            pwm_enable(false);
+        }
+    }
+}
+
+/**
+ *  Scale input PWM duty cycle down by 25%
+ *  This will lower the average voltage from VM on the motor
+ *  NOTE: Might not use this function if able to get 12V rated motors.
+ */
+static inline uint8_t pwm_scale_duty_cycle(uint8_t duty_cycle_percent) {
+    /**
+     * Battery is at ~8V and motor supplies are rated for 6V, so scale down the
+     * applied input PWM duty cycle by 25% so that average voltage will be ~6V
+     * max. This function should never return 0 because that is the same as if
+     * PWM is disabled.
+     */
+    return duty_cycle_percent == 1 ? duty_cycle_percent
+                                   : (duty_cycle_percent * 3 / 4);
+}
+
+/**
+ * Set duty cycle of PWM for specified motor driver
+ */
+void pwm_set_duty_cycle(mdrv_enum mdrv, uint8_t duty_cycle_percent) {
+    ASSERT(initialized);
+    const bool enable =
+        duty_cycle_percent > 0; // Check if given duty cycle is > 0%
+    if (enable) {               // If duty cycle is greater than 0
+        *pwm_cfgs[mdrv].ccr = pwm_scale_duty_cycle(
+            duty_cycle_percent); // Set PWM to scaled target duty cycle
+    }
+    pwm_channel_enable(mdrv,
+                       enable); // Enable PWM output of MCU to motor driver
+}

--- a/src/fw/drivers/pwm.h
+++ b/src/fw/drivers/pwm.h
@@ -1,0 +1,12 @@
+#include <stdint.h>
+
+// Driver that emulates hardware PWM with timers
+typedef enum {
+    DRV8848_RIGHT1,
+    DRV8848_RIGHT2,
+    DRV8848_LEFT1,
+    DRV8848_LEFT2
+} mdrv_enum;
+
+void pwm_init(void);
+void pwm_set_duty_cycle(mdrv_enum, uint8_t);

--- a/src/fw/drivers/uart.c
+++ b/src/fw/drivers/uart.c
@@ -4,9 +4,9 @@
 #include "drivers/io.h"
 #include "drivers/ring_buffer.h"
 #include <assert.h>
+#include <msp430.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <msp430.h>
 
 // UART ring buffer constants
 #define UART_BUFFER_SIZE (16U)
@@ -14,7 +14,6 @@
 static struct ring_buffer *uart_ring_buffer = NULL;
 
 // UART configuration constants
-#define SMCLK (CYCLES_16MHZ)
 #define BRCLK (SMCLK)
 #define UART_BAUDRATE (115200U)
 static_assert(UART_BAUDRATE <= BRCLK / 16.0f,
@@ -277,9 +276,9 @@ void uart_init_assert(void) {
     uart_init();
 }
 
-void uart_trace_assert(const char* str) {
+void uart_trace_assert(const char *str) {
     int i = 0;
-    while(str[i] != '\0') {
+    while (str[i] != '\0') {
         uart_putchar_polling(str[i]);
         i++;
     }

--- a/src/fw/drivers/uart.h
+++ b/src/fw/drivers/uart.h
@@ -7,8 +7,7 @@ void uart_putchar_polling(char);
 void uart_putchar_interrupt(char);
 void uart_tx_start(void);
 void _putchar(char); // mpaland low-level output function needed for printf()
-                    
+
 // These functions should ONLY be called by assert_handler()
 void uart_init_assert(void);
 void uart_trace_assert(const char *str);
-

--- a/src/fw/test/test.c
+++ b/src/fw/test/test.c
@@ -4,6 +4,7 @@
 #include "drivers/led.h"
 #include "drivers/io.h"
 #include "drivers/uart.h"
+#include "drivers/pwm.h"
 #include "common/defines.h"
 #include "common/assert_handler.h"
 #include "common/trace.h"
@@ -18,7 +19,7 @@ static void test_setup(void) {
 SUPPRESS_UNUSED
 static void test_assert(void) {
     test_setup();
-    ASSERT(0)
+    ASSERT(0);
 }
 
 SUPPRESS_UNUSED
@@ -155,6 +156,33 @@ static void test_uart_interrupt(void) {
         uart_putchar_interrupt('d');
         uart_putchar_interrupt('\n');
         BUSY_WAIT_ms(500);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_pwm(void) {
+    test_setup();
+    trace_init();
+    pwm_init();
+    const uint8_t duty_cycles[6] = {100, 75, 50, 25, 1, 0};
+    const uint16_t wait_time = 3000;
+    while(1) {
+        for(uint8_t i = 0; i < ARRAY_SIZE(duty_cycles); i++) {
+            TRACE("Set duty cycle for IN1 to %d for %d ms", duty_cycles[i], wait_time);
+            pwm_set_duty_cycle(DRV8848_RIGHT1, duty_cycles[i]);
+            pwm_set_duty_cycle(DRV8848_RIGHT2, 0);
+            pwm_set_duty_cycle(DRV8848_LEFT1, duty_cycles[i]);
+            pwm_set_duty_cycle(DRV8848_LEFT2, 0);
+            BUSY_WAIT_ms(wait_time);
+        }
+        for(uint8_t i = 0; i < ARRAY_SIZE(duty_cycles); i++) {
+            TRACE("Set duty cycle for IN2 to %d for %d ms", duty_cycles[i], wait_time);
+            pwm_set_duty_cycle(DRV8848_RIGHT1, 0);
+            pwm_set_duty_cycle(DRV8848_RIGHT2, duty_cycles[i]); 
+            pwm_set_duty_cycle(DRV8848_LEFT1, 0);
+            pwm_set_duty_cycle(DRV8848_LEFT2, duty_cycles[i]);
+            BUSY_WAIT_ms(wait_time);
+        }
     }
 }
 


### PR DESCRIPTION
Adding pwm_init() to intialize timers connected to PWM pins on Launchpad, and pwm_set_duty_cycle() to control the duty cycle of the PWM output through the timer registers via Capture & Compare registers. Have not tested PWM output on oscilloscope yet prior to this commit, but the TRACE of the PWM output duty cycle appears to be working.