### PR TITLE
pwm (feat): Adding PWM drivers with DRV8848 pin configurations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ else
 MAIN_SRC_FILE = $(TEST_DIR)/$(TEST).c
 endif
 SRC_FILES_APP = drive.c enemy.c
-SRC_FILES_DRIVERS = io.c led.c mcu_init.c uart.c ring_buffer.c pwm.c
+SRC_FILES_DRIVERS = io.c led.c mcu_init.c uart.c ring_buffer.c pwm.c drv8848.c
 SRC_FILES_MOTOR = motors.c
 SRC_FILES_COMMON = assert_handler.c trace.c
 SRC_FILES_PRINTF = printf.c

--- a/src/fw/drivers/drv8848.c
+++ b/src/fw/drivers/drv8848.c
@@ -1,0 +1,126 @@
+#include "drivers/drv8848.h"
+#include "drivers/pwm.h"
+#include "drivers/io.h"
+#include "common/assert_handler.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+
+static bool initialized = false;
+
+static const drv8848_enum motor_sides[][2] = {
+    [MOTORS_RIGHT] = {DRV8848_RIGHT1, DRV8848_RIGHT2},
+    [MOTORS_LEFT] = {DRV8848_LEFT1, DRV8848_LEFT2}
+};
+
+/**
+ * Checks io pins (besides the PWM inputs) for motor drivers are configured correctly
+ */
+static void drv8848_assert_io_config() {
+    // IO config for ENABLE pin of motor driver
+    const struct io_config motor_enable_config = {
+        .io_sel = IO_SEL_GPIO,
+        .io_dir = IO_DIR_OUTPUT,
+        .io_ren = IO_REN_DISABLE,
+        .io_out = IO_OUT_LOW
+    };
+    
+    // IO config for nFAULT pin of motor driver
+    const struct io_config motor_nfault_config = {
+        .io_sel = IO_SEL_GPIO,
+        .io_dir = IO_DIR_INPUT,
+        .io_ren = IO_REN_ENABLE,
+        .io_out = IO_OUT_HIGH
+    };
+    struct io_config curr_motor_enable_config, curr_motor_nfault_config;
+    io_get_current_config(MOTOR_ENABLE, &curr_motor_enable_config);
+    io_get_current_config(MOTOR_NFAULT, &curr_motor_nfault_config);
+    ASSERT(io_config_compare(&motor_enable_config, &curr_motor_enable_config));
+    ASSERT(io_config_compare(&motor_nfault_config, &curr_motor_nfault_config));
+}
+
+/**
+ * Initializes motor driver PWM and checks IO configuration
+ * for other pins of motor driver (enable and nFAULT)
+ */
+void drv8848_init(void) {
+   ASSERT(!initialized); 
+   
+   pwm_init();
+   drv8848_assert_io_config();
+   initialized = true;
+}
+
+/**
+ * Set the mode of the motor driver
+ * Mode depends on state of PWM inputs
+ */
+void drv8848_set_mode(motor_side_enum side, drv8848_mode_enum mode, uint8_t duty_cycle) {
+    /**
+     * xIN1 xIN2 xOUT1 xOUT2 Function (DC Motor)
+     * 0    0    Z     Z     Coast (fast decay)
+     * 0    1    L     H     Reverse
+     * 1    0    H     L     Forward
+     * 1    1    L     L     Brake (slow decay)
+     */
+ switch(mode) {
+    case DRV8848_MODE_COAST:
+            // Set both inputs to LOW (0% duty cycle)
+            drv8848_set_pwm(motor_sides[side][0], 0); // Set left/right motor xIN1 to 0% duty cycle
+            drv8848_set_pwm(motor_sides[side][1], 0); // Set left/right motor xIN2 to 0% duty cycle
+            //drv8848_set_pwm(DRV8848_RIGHT1, 0);
+            //drv8848_set_pwm(DRV8848_RIGHT2, 0);
+            //drv8848_set_pwm(DRV8848_LEFT1, 0);
+            //drv8848_set_pwm(DRV8848_LEFT2, 0);
+            break;
+    case DRV8848_MODE_FORWARD:
+            // PWM xIN1, Disable xIN2
+            drv8848_set_pwm(motor_sides[side][0], duty_cycle); // Set left/right motor xIN1 to current duty cycle
+            drv8848_set_pwm(motor_sides[side][1], 0); // Set left/right motor xIN2 to 0% duty cycle
+            //drv8848_set_pwm(DRV8848_RIGHT1, curr_pwm_dutycycle);
+            //drv8848_set_pwm(DRV8848_RIGHT2, 0);
+            //drv8848_set_pwm(DRV8848_LEFT1, curr_pwm_dutycycle);
+            //drv8848_set_pwm(DRV8848_LEFT2, 0);
+            break;
+    case DRV8848_MODE_REVERSE:
+            // Disable xIN1, PWM xIN2
+            drv8848_set_pwm(motor_sides[side][0], 0); // Set left/right motor xIN1 to 0% duty cycle
+            drv8848_set_pwm(motor_sides[side][1], duty_cycle); // Set left/right motor xIN2 to current duty cycle
+            //drv8848_set_pwm(DRV8848_RIGHT1, 0);
+            //drv8848_set_pwm(DRV8848_RIGHT2, curr_pwm_dutycycle);
+            //drv8848_set_pwm(DRV8848_LEFT1, 0);
+            //drv8848_set_pwm(DRV8848_LEFT2, curr_pwm_dutycycle);
+            break;
+    case DRV8848_MODE_STOP:
+            // Enable both inputs
+            drv8848_set_pwm(motor_sides[side][0], 100); // Set left/right motor xIN1 to 100% duty cycle
+            drv8848_set_pwm(motor_sides[side][1], 100); // Set left/right motor xIN2 to 100% duty cycle
+            //drv8848_set_pwm(DRV8848_RIGHT1, 100);
+            //drv8848_set_pwm(DRV8848_RIGHT2, 100);
+            //drv8848_set_pwm(DRV8848_LEFT1, 100);
+            //drv8848_set_pwm(DRV8848_LEFT2, 100);
+            break;
+ }
+}
+
+/**
+ * Set the PWM duty cycle inputs of the motor driver
+ */
+static_assert(DRV8848_RIGHT1 == (int)PWM_DRV8848_RIGHT1, "PWM and DRV RIGHT1 enum mismatch");
+static_assert(DRV8848_RIGHT2 == (int)PWM_DRV8848_RIGHT2, "PWM and DRV RIGHT2 enum mismatch");
+static_assert(DRV8848_LEFT1 == (int)PWM_DRV8848_LEFT1, "PWM and DRV LEFT1 enum mismatch");
+static_assert(DRV8848_LEFT2 == (int)PWM_DRV8848_LEFT2, "PWM and DRV LEFT2 enum mismatch");
+void drv8848_set_pwm(drv8848_enum device, uint8_t duty_cycle) {
+    pwm_set_duty_cycle((mdrv_enum)device, duty_cycle);
+}
+
+/**
+ * Enable or disable both motor drivers
+ */
+void drv8848_enable(bool enable) {
+   // Enable both motors
+   if(enable)
+    io_set_out(MOTOR_ENABLE, IO_OUT_HIGH);
+   else
+    io_set_out(MOTOR_ENABLE, IO_OUT_LOW);
+}

--- a/src/fw/drivers/drv8848.h
+++ b/src/fw/drivers/drv8848.h
@@ -1,0 +1,26 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    MOTORS_RIGHT,
+    MOTORS_LEFT
+} motor_side_enum;
+
+typedef enum {
+    DRV8848_RIGHT1,
+    DRV8848_RIGHT2,
+    DRV8848_LEFT1,
+    DRV8848_LEFT2
+} drv8848_enum;
+
+typedef enum {
+    DRV8848_MODE_COAST,
+    DRV8848_MODE_FORWARD, 
+    DRV8848_MODE_REVERSE,
+    DRV8848_MODE_STOP
+} drv8848_mode_enum;
+
+void drv8848_init(void);
+void drv8848_set_mode(motor_side_enum side, drv8848_mode_enum mode, uint8_t duty_cycle);
+void drv8848_set_pwm(drv8848_enum device, uint8_t duty_cycle);
+void drv8848_enable(bool enable);

--- a/src/fw/drivers/io.c
+++ b/src/fw/drivers/io.c
@@ -99,6 +99,8 @@ static const struct io_config io_initial_configs[IO_PORT_CNT *
                          IO_OUT_LOW},
     [MOTOR_LEFT_IN1] = {IO_SEL_ALT2, IO_DIR_OUTPUT, IO_REN_DISABLE, IO_OUT_LOW},
     [MOTOR_LEFT_IN2] = {IO_SEL_ALT2, IO_DIR_OUTPUT, IO_REN_DISABLE, IO_OUT_LOW},
+    [MOTOR_ENABLE] = {IO_SEL_GPIO, IO_DIR_OUTPUT, IO_REN_DISABLE, IO_OUT_LOW},
+    [MOTOR_NFAULT] = {IO_SEL_GPIO, IO_DIR_INPUT, IO_REN_ENABLE, IO_OUT_HIGH},
 
     // Laster Range Sensor pins
     [XSHUT_RIGHT] = {IO_SEL_GPIO, IO_DIR_OUTPUT, IO_REN_DISABLE, IO_OUT_LOW},
@@ -163,12 +165,12 @@ static const struct io_config io_initial_configs[IO_PORT_CNT *
     [IO_UNUSED_71] = IO_UNUSED_CONFIG,
     [IO_UNUSED_72] = IO_UNUSED_CONFIG,
     [IO_UNUSED_73] = IO_UNUSED_CONFIG,
-    [IO_UNUSED_74] = IO_UNUSED_CONFIG,
+    //[IO_UNUSED_74] = IO_UNUSED_CONFIG,
     [IO_UNUSED_75] = IO_UNUSED_CONFIG,
     [IO_UNUSED_76] = IO_UNUSED_CONFIG,
     [IO_UNUSED_77] = IO_UNUSED_CONFIG,
     [IO_UNUSED_80] = IO_UNUSED_CONFIG,
-    [IO_UNUSED_82] = IO_UNUSED_CONFIG
+    //[IO_UNUSED_82] = IO_UNUSED_CONFIG
 #elif SUMOBOT
     // Unused IO Pins
     [IO_UNUSED_11] = IO_UNUSED_CONFIG,
@@ -205,12 +207,12 @@ static const struct io_config io_initial_configs[IO_PORT_CNT *
     [IO_UNUSED_71] = IO_UNUSED_CONFIG,
     [IO_UNUSED_72] = IO_UNUSED_CONFIG,
     [IO_UNUSED_73] = IO_UNUSED_CONFIG,
-    [IO_UNUSED_74] = IO_UNUSED_CONFIG,
+    //[IO_UNUSED_74] = IO_UNUSED_CONFIG,
     [IO_UNUSED_75] = IO_UNUSED_CONFIG,
     [IO_UNUSED_76] = IO_UNUSED_CONFIG,
     [IO_UNUSED_77] = IO_UNUSED_CONFIG,
     [IO_UNUSED_80] = IO_UNUSED_CONFIG,
-    [IO_UNUSED_82] = IO_UNUSED_CONFIG
+    //[IO_UNUSED_82] = IO_UNUSED_CONFIG
 #endif
 };
 
@@ -314,6 +316,9 @@ void io_get_current_config(io_signal_enum signal, struct io_config *config) {
             } else if (config->io_dir == 1) {
                 config->io_sel = (io_sel_enum)2; // IO_SEL is actually = 2
             }
+        }
+        else { // Set IO_SEL = 0
+            config->io_sel = (io_sel_enum)0;
         }
     } else { // IO_SEL will only be 0/1
         config->io_sel =

--- a/src/fw/drivers/io.h
+++ b/src/fw/drivers/io.h
@@ -202,6 +202,8 @@ typedef enum {
     MOTOR_RIGHT_IN2 = IO_24, // P2.4
     MOTOR_LEFT_IN1 = IO_15,  // P1.5
     MOTOR_LEFT_IN2 = IO_14,  // P1.4
+    MOTOR_ENABLE = IO_82,    // P8.2
+    MOTOR_NFAULT = IO_74,    // P7.4
 
     // Laser Range Sensor pins
     //-- Reset pins
@@ -263,12 +265,12 @@ typedef enum {
     IO_UNUSED_71 = IO_71,
     IO_UNUSED_72 = IO_72,
     IO_UNUSED_73 = IO_73,
-    IO_UNUSED_74 = IO_74,
+    //IO_UNUSED_74 = IO_74,
     IO_UNUSED_75 = IO_75,
     IO_UNUSED_76 = IO_76,
     IO_UNUSED_77 = IO_77,
     IO_UNUSED_80 = IO_80,
-    IO_UNUSED_82 = IO_82
+    //IO_UNUSED_82 = IO_82
 #elif SUMOBOT // Actual sumo bot
     // Detect HW Type pin
     DETECT_HW_TYPE_PIN = IO_37,
@@ -281,6 +283,8 @@ typedef enum {
     MOTOR_RIGHT_IN2 = IO_24, // P2.4
     MOTOR_LEFT_IN1 = IO_15,  // P1.5
     MOTOR_LEFT_IN2 = IO_14,  // P1.4
+    MOTOR_ENABLE = IO_82,    // P8.2
+    MOTOR_NFAULT = IO_74,    // P7.4
 
     // Laser Range Sensor pins
     //-- Reset pins
@@ -340,12 +344,12 @@ typedef enum {
     IO_UNUSED_71 = IO_71,
     IO_UNUSED_72 = IO_72,
     IO_UNUSED_73 = IO_73,
-    IO_UNUSED_74 = IO_74,
+    //IO_UNUSED_74 = IO_74,
     IO_UNUSED_75 = IO_75,
     IO_UNUSED_76 = IO_76,
     IO_UNUSED_77 = IO_77,
     IO_UNUSED_80 = IO_80,
-    IO_UNUSED_82 = IO_82
+    //IO_UNUSED_82 = IO_82
 
 #endif
 } io_signal_enum;

--- a/src/fw/drivers/pwm.c
+++ b/src/fw/drivers/pwm.c
@@ -28,10 +28,10 @@ struct pwm_channel_cfg {
 };
 
 static struct pwm_channel_cfg pwm_cfgs[] = {
-    [MOTOR_RIGHT_IN1] = {.enable = false, .cctl = &TA2CCTL2, .ccr = &TA2CCR2},
-    [MOTOR_RIGHT_IN2] = {.enable = false, .cctl = &TA2CCTL1, .ccr = &TA2CCR1},
-    [MOTOR_LEFT_IN1] = {.enable = false, .cctl = &TA0CCTL4, .ccr = &TA0CCR4},
-    [MOTOR_LEFT_IN2] = {.enable = false, .cctl = &TA0CCTL3, .ccr = &TA0CCR3}};
+    [PWM_DRV8848_RIGHT1] = {.enable = false, .cctl = &TA2CCTL2, .ccr = &TA2CCR2},
+    [PWM_DRV8848_RIGHT2] = {.enable = false, .cctl = &TA2CCTL1, .ccr = &TA2CCR1},
+    [PWM_DRV8848_LEFT1] = {.enable = false, .cctl = &TA0CCTL4, .ccr = &TA0CCR4},
+    [PWM_DRV8848_LEFT2] = {.enable = false, .cctl = &TA0CCTL3, .ccr = &TA0CCR3}};
 
 /**
  * Initialize PWM timer registers
@@ -89,8 +89,8 @@ static void pwm_enable(bool enable) {
      * MC_0: Timer is halted
      * MC_1: Up mode (Count up to TAxCCR0)
      */
-    TA0CTL = (enable ? MC_1 : MC_0) + TACLR;
-    TA2CTL = (enable ? MC_1 : MC_0) + TACLR;
+    TA0CTL |= (enable ? MC_1 : MC_0) + TACLR;
+    TA2CTL |= (enable ? MC_1 : MC_0) + TACLR;
 }
 
 /**

--- a/src/fw/drivers/pwm.h
+++ b/src/fw/drivers/pwm.h
@@ -2,10 +2,10 @@
 
 // Driver that emulates hardware PWM with timers
 typedef enum {
-    DRV8848_RIGHT1,
-    DRV8848_RIGHT2,
-    DRV8848_LEFT1,
-    DRV8848_LEFT2
+    PWM_DRV8848_RIGHT1,
+    PWM_DRV8848_RIGHT2,
+    PWM_DRV8848_LEFT1,
+    PWM_DRV8848_LEFT2
 } mdrv_enum;
 
 void pwm_init(void);

--- a/src/fw/test/test.c
+++ b/src/fw/test/test.c
@@ -5,6 +5,7 @@
 #include "drivers/io.h"
 #include "drivers/uart.h"
 #include "drivers/pwm.h"
+#include "drivers/drv8848.h"
 #include "common/defines.h"
 #include "common/assert_handler.h"
 #include "common/trace.h"
@@ -182,6 +183,27 @@ static void test_pwm(void) {
             pwm_set_duty_cycle(DRV8848_LEFT1, 0);
             pwm_set_duty_cycle(DRV8848_LEFT2, duty_cycles[i]);
             BUSY_WAIT_ms(wait_time);
+        }
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_drv8848(void) {
+    test_setup();
+    trace_init();
+    drv8848_init();
+    const uint8_t duty_cycles[6] = {100, 75, 50, 25, 1, 0};
+    const drv8848_mode_enum drv8848_modes[4] = {DRV8848_MODE_FORWARD, DRV8848_MODE_COAST, DRV8848_MODE_REVERSE, DRV8848_MODE_STOP};
+    const char* drv8848_mode_names[4] = {"COAST", "FORWARD", "REVERSE", "BRAKE"};
+    const uint16_t wait_time = 3000;
+    while(1) {
+        for(uint8_t i = 0; i < ARRAY_SIZE(drv8848_modes); i++) {
+            for(uint8_t j = 0; j < ARRAY_SIZE(duty_cycles); j++) {
+                TRACE("Set drv8848 mode to %s with duty cycle %d", drv8848_mode_names[drv8848_modes[i]], duty_cycles[j]);
+                drv8848_set_mode(MOTORS_RIGHT, drv8848_modes[i], duty_cycles[j]);
+                drv8848_set_mode(MOTORS_LEFT, drv8848_modes[i], duty_cycles[j]);
+                BUSY_WAIT_ms(wait_time);
+            }
         }
     }
 }


### PR DESCRIPTION
DRV8848 still lacks the enable pin signal, but PWM with different duty cycles and different modes of DRV8848 (coast, forward, reverse, break) have been tested.